### PR TITLE
30-добавить-нумерацию-default-account-title

### DIFF
--- a/app/src/java/com/kavencore/moneyharbor/app/infrastructure/repository/AccountRepository.java
+++ b/app/src/java/com/kavencore/moneyharbor/app/infrastructure/repository/AccountRepository.java
@@ -4,19 +4,43 @@ import com.kavencore.moneyharbor.app.entity.Account;
 import com.kavencore.moneyharbor.app.entity.Currency;
 import com.kavencore.moneyharbor.app.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AccountRepository extends JpaRepository<Account, UUID> {
-    int deleteByIdAndUserId(UUID attr0, UUID id);
+    int deleteByIdAndUserId(UUID accId, UUID userId);
 
-    long countByUserAndCurrencyAndTitleStartingWith(User user, Currency currency, String StartingWithQuery);
+
+    List<Account> findTopByUserAndCurrencyAndTitleStartingWithOrderByTitleDesc(User user, Currency currency, String prefix);
 
     List<Account> findAllByUser(User user);
 
     Optional<Account> findByIdAndUserId(UUID id, UUID userId);
+
+    /**
+     * Опишу логику, т.к. она достаточно сложная.
+     * LENGTH(:titlePrefix) + 1 – получаем длину префикса в названии. {валюта}_счёт_. И сдвигаемся на одну позицию вперёд
+     * SUBSTRING... as LONG стартуем с полученной позиции и приводим к числовому типу данных
+     * Берём максимальное число
+     * a.title ~ '_\d+$' проверяет с помощью regex оставляет только те запросы, которые содержат после счет_ - цифры
+     * value - {всё выражение}, nativeQuery = true необходимо для того чтобы regex работал
+    */
+    @Query(value = """
+        SELECT MAX(CAST(SUBSTRING(a.title, LENGTH(:titlePrefix) + 1) as BIGINT))
+        from accounts a
+        where a.user_id = :userId and
+        a.currency = :currency and
+        a.title ~ '_\\d+$'
+        """, nativeQuery = true)
+    Optional<Long> findMaxAccountNumberThisCurrency(
+            @Param("userId") UUID user,
+            @Param("currency") String currency,
+            @Param("titlePrefix") String titlePrefix
+    );
 
 
 }

--- a/app/src/java/com/kavencore/moneyharbor/app/infrastructure/repository/AccountRepository.java
+++ b/app/src/java/com/kavencore/moneyharbor/app/infrastructure/repository/AccountRepository.java
@@ -14,33 +14,11 @@ import java.util.UUID;
 public interface AccountRepository extends JpaRepository<Account, UUID> {
     int deleteByIdAndUserId(UUID accId, UUID userId);
 
-
-    List<Account> findTopByUserAndCurrencyAndTitleStartingWithOrderByTitleDesc(User user, Currency currency, String prefix);
-
     List<Account> findAllByUser(User user);
 
     Optional<Account> findByIdAndUserId(UUID id, UUID userId);
 
-    /**
-     * Опишу логику, т.к. она достаточно сложная.
-     * LENGTH(:titlePrefix) + 1 – получаем длину префикса в названии. {валюта}_счёт_. И сдвигаемся на одну позицию вперёд
-     * SUBSTRING... as LONG стартуем с полученной позиции и приводим к числовому типу данных
-     * Берём максимальное число
-     * a.title ~ '_\d+$' проверяет с помощью regex оставляет только те запросы, которые содержат после счет_ - цифры
-     * value - {всё выражение}, nativeQuery = true необходимо для того чтобы regex работал
-    */
-    @Query(value = """
-        SELECT MAX(CAST(SUBSTRING(a.title, LENGTH(:titlePrefix) + 1) as BIGINT))
-        from accounts a
-        where a.user_id = :userId and
-        a.currency = :currency and
-        a.title ~ '_\\d+$'
-        """, nativeQuery = true)
-    Optional<Long> findMaxAccountNumberThisCurrency(
-            @Param("userId") UUID user,
-            @Param("currency") String currency,
-            @Param("titlePrefix") String titlePrefix
-    );
+    List<Account> findByUserIdAndCurrency(UUID userId, Currency currency);
 
 
 }

--- a/app/src/java/com/kavencore/moneyharbor/app/infrastructure/repository/AccountRepository.java
+++ b/app/src/java/com/kavencore/moneyharbor/app/infrastructure/repository/AccountRepository.java
@@ -1,13 +1,22 @@
 package com.kavencore.moneyharbor.app.infrastructure.repository;
 
 import com.kavencore.moneyharbor.app.entity.Account;
+import com.kavencore.moneyharbor.app.entity.Currency;
+import com.kavencore.moneyharbor.app.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AccountRepository extends JpaRepository<Account, UUID> {
     int deleteByIdAndUserId(UUID attr0, UUID id);
 
+    long countByUserAndCurrencyAndTitleStartingWith(User user, Currency currency, String StartingWithQuery);
+
+    List<Account> findAllByUser(User user);
+
     Optional<Account> findByIdAndUserId(UUID id, UUID userId);
+
+
 }

--- a/app/src/java/com/kavencore/moneyharbor/app/infrastructure/service/AccountService.java
+++ b/app/src/java/com/kavencore/moneyharbor/app/infrastructure/service/AccountService.java
@@ -26,7 +26,7 @@ public class AccountService {
     private final UserRepository userRepository;
     private final AccountMapper accountMapper;
 
-    private static final String TITLE_SUFFIX = "_счет";
+    private static final String TITLE_SUFFIX = "_счет_";
 
     @Transactional
     public CreatedAccountResult createAccount(@Valid CreateAccountRequestDto dto, UUID userId) {
@@ -55,7 +55,15 @@ public class AccountService {
 
     private void applyDefaults(Account acc) {
         if (acc.getTitle() == null) {
-            acc.setTitle(acc.getCurrency().name() + TITLE_SUFFIX);
+            String titleQuery = acc.getCurrency().name() + TITLE_SUFFIX;
+            long countUserNonsalaryAccounts = accountRepository.
+                    countByUserAndCurrencyAndTitleStartingWith(
+                            acc.getUser(),
+                            acc.getCurrency(),
+                            titleQuery)
+                    + 1;
+
+            acc.setTitle(acc.getCurrency().name() + TITLE_SUFFIX + countUserNonsalaryAccounts);
         }
         if (acc.getAmount() == null) {
             acc.setAmount(BigDecimal.ZERO);

--- a/app/src/java/com/kavencore/moneyharbor/app/infrastructure/service/AccountService.java
+++ b/app/src/java/com/kavencore/moneyharbor/app/infrastructure/service/AccountService.java
@@ -16,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -68,11 +69,18 @@ public class AccountService {
 
     private long calculateNextAccountNumber(Account acc) {
         String titleQuery = acc.getCurrency().name() + TITLE_SUFFIX;
-        long nextAccountNumber = accountRepository.findMaxAccountNumberThisCurrency(
+
+        List<Account> usersAccWithThisCurrency = accountRepository.findByUserIdAndCurrency(
                 acc.getUser().getId(),
-                acc.getCurrency().name(),
-                titleQuery
-        ).orElse(0L) + 1;
+                acc.getCurrency()
+        );
+        long nextAccountNumber = usersAccWithThisCurrency.stream()
+                .map(Account::getTitle)
+                .filter(title -> title.startsWith(titleQuery))
+                .map(title -> title.substring(titleQuery.length()))
+                .mapToLong(Long::parseLong)
+                .max()
+                .orElse(0L) + 1;
         return nextAccountNumber;
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,9 +19,6 @@ subprojects {
 			// Это исправляет проблемы с кодировкой в консоли Windows
 			jvmArgs("-Dfile.encoding=UTF-8")
 
-			// Это заставляет тесты работать в одном процессе с Gradle,
-			// что решает ошибку "Could not find or load main class"
-			setForkEvery(0)
 		}
 	}
 	configurations.configureEach {

--- a/component-test/src/test/java/AccountJson.java
+++ b/component-test/src/test/java/AccountJson.java
@@ -6,7 +6,9 @@ public enum AccountJson {
     CREATE_MISSING_CURRENCY("/json/accounts/create-missing-currency.json"),
     CREATE_AMOUNT_SCALE_3("/json/accounts/create-amount-scale-3.json"),
     CREATE_AMOUNT_INTEGER_TOO_LONG("/json/accounts/create-amount-integer-too-long.json"),
-    CREATE_TITLE_WRONG_TYPE("/json/accounts/create-title-wrong-type.json");
+    CREATE_TITLE_WRONG_TYPE("/json/accounts/create-title-wrong-type.json"),
+    CREATE_STANDARD_USD("/json/accounts/create-standard-usd.json"),
+    CREATE_STANDARD_RUB("/json/accounts/create-standard-rub.json");
 
     private final String path;
 

--- a/component-test/src/test/java/AccountsComponentTest.java
+++ b/component-test/src/test/java/AccountsComponentTest.java
@@ -1,8 +1,6 @@
 import com.kavencore.moneyharbor.app.entity.Account;
-import com.kavencore.moneyharbor.app.entity.Currency;
 import com.kavencore.moneyharbor.app.entity.User;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -13,7 +11,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,12 +24,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @DisplayName("Accounts API — component tests")
 class AccountsComponentTest extends BaseComponentTest {
-
-    @AfterEach
-    void tearDown() {
-        accountRepository.deleteAll();
-    }
-
 
     @Test
     @DisplayName("Post /accounts - 201, атрибуты сохранены в базе")
@@ -85,6 +76,9 @@ class AccountsComponentTest extends BaseComponentTest {
         String jsonRUB = AccountJson.CREATE_STANDARD_RUB.load();
         performPostAuth(ACCOUNTS_PATH, jsonRUB);
 
+        String jsonRUB2 = AccountJson.CREATE_STANDARD_RUB.load();
+        performPostAuth(ACCOUNTS_PATH, jsonRUB2);
+
         String json = AccountJson.CREATE_WITHOUT_TITLE.load();
         performPostAuth(ACCOUNTS_PATH, json).andExpect(status().isCreated());
 
@@ -94,7 +88,7 @@ class AccountsComponentTest extends BaseComponentTest {
                 .filter(a -> a.getTitle().equals("USD_счет_2"))
                 .findFirst();
 
-        assertThat(userAccounts).hasSize(3);
+        assertThat(userAccounts).hasSize(4);
         assertThat(newAccount).isPresent();
         assertThat(newAccount.get().getTitle()).isEqualTo("USD_счет_2");
         assertThat(newAccount.get().getAmount()).isEqualByComparingTo("0.00");

--- a/component-test/src/test/resources/json/accounts/create-standard-rub.json
+++ b/component-test/src/test/resources/json/accounts/create-standard-rub.json
@@ -1,0 +1,5 @@
+{
+  "currency": "RUB",
+  "amount": 0.00,
+  "title": "RUB_счет_1"
+}

--- a/component-test/src/test/resources/json/accounts/create-standard-usd.json
+++ b/component-test/src/test/resources/json/accounts/create-standard-usd.json
@@ -1,0 +1,5 @@
+{
+  "currency": "USD",
+  "amount": 0.00,
+  "title": "USD_счет_1"
+}

--- a/component-test/src/test/resources/json/accounts/create_standard_rub2.json
+++ b/component-test/src/test/resources/json/accounts/create_standard_rub2.json
@@ -1,0 +1,5 @@
+{
+  "currency": "RUB",
+  "amount": 0.00,
+  "title": "RUB_счет_2"
+}


### PR DESCRIPTION
Исправлена логика именования title новых счетов. Теперь они формируются по принципу {валюта}_счет_{порядковый номер счета в данной валюте}
Логика работы протестирована


Отдельно отмечу важный момент

Нумерация счетов подсчитывается с помощью получения количества счетов с необходимой маской в нашей БД. Исхожу из того что записи в аккаунтах удаляться не будут
Если будут то логика будет затирать существующие счета и нужно её менять. Разбивать все счета на сплиты и смотреть самое большое число и увеличивать его